### PR TITLE
corrected Suppressed API warning(s) -> Creating an ndarray from ragge…

### DIFF
--- a/ScientificProgrammer_/gmres_example.py
+++ b/ScientificProgrammer_/gmres_example.py
@@ -1,4 +1,6 @@
 import numpy as np
+import warnings
+warnings.filterwarnings("ignore", category=np.VisibleDeprecationWarning) 
 
 '''
 Used psuedo code form .png files, 


### PR DESCRIPTION
…d nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify, dtype=object when creating the ndarray.